### PR TITLE
fix: npm is not running `prepare` script as root

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script: >
   docker run --network="host" platform-test-suite:local 127.0.0.1:3000:3010 -k=$FAUCET_PRIVATE_KEY -n=regtest --dpns-tld-identity-private-key=$DPNS_TOP_LEVEL_IDENTITY_PRIVATE_KEY --dpns-tld-identity-id=$DPNS_TOP_LEVEL_IDENTITY_ID --dpns-contract-id=$DPNS_CONTRACT_ID
 
 after_script:
-  - mn stop local
+  - mn stop
 
 deploy:
   provider: script

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk update && \
 # for easier app bind mounting for local development
 WORKDIR /
 
+RUN npm config set unsafe-perm true
+
 COPY package.json package-lock.json ./
 RUN npm ci --production
 

--- a/test/functional/platform/Document.spec.js
+++ b/test/functional/platform/Document.spec.js
@@ -1,3 +1,5 @@
+const { expect } = require('chai');
+
 const getDataContractFixture = require(
   '@dashevo/dpp/lib/test/fixtures/getDataContractFixture',
 );
@@ -6,7 +8,6 @@ const getIdentityFixture = require(
 );
 
 const createClientWithFundedWallet = require('../../../lib/test/createClientWithFundedWallet');
-const { expect } = require('chai');
 
 describe('Platform', () => {
   describe('Document', () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Inside Docker `npm` is not running `prepare` script as `root`

## What was done?
<!--- Describe your changes in detail -->
Updating `npm` config before `npm ci`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
