### PR TITLE
fix: faucet client singleton

### DIFF
--- a/lib/test/createFaucetClient.js
+++ b/lib/test/createFaucetClient.js
@@ -21,12 +21,14 @@ function createFaucetClient() {
     },
   };
 
-  return new Dash.Client({
+  faucetClient = new Dash.Client({
     ...clientOpts,
     wallet: {
       privateKey: process.env.FAUCET_PRIVATE_KEY,
     },
   });
+
+  return faucetClient;
 }
 
 module.exports = createFaucetClient;


### PR DESCRIPTION
## Issue being fixed or feature implemented
Fix caching for `createFaucetClient` - return cached instance if it was faucet client was already created in the past

## What was done?
Write a value to the faucetClient variable instead of returning it right away

## How Has This Been Tested?
Run `npm test`

## Breaking Changes
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
