### PR TITLE
docs: clarify devnet is valid option for --network

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Usage: test <seed> [options]
               --npm-install=pkg                             - install npm package before running the suite
   -s=a,b,c    --scope=a,b,c                                 - test scope to run
   -k=key      --faucet-key=key                              - faucet private key string
-  -n=network  --network=network                             - use regtest or testnet
+  -n=network  --network=network                             - use regtest, devnet or testnet
               --dpns-tld-identity-private-key=private_key   - top level identity private key
               --dpns-tld-identity-id=identity_id            - top level identity id
               --dpns-contract-id=contract_id                - dpns contract id
@@ -78,7 +78,7 @@ Usage: test <seed> [options]
               --npm-install=pkg                             - install npm package before running the suite
   -s=a,b,c    --scope=a,b,c                                 - test scope to run
   -k=key      --faucet-key=key                              - faucet private key string
-  -n=network  --network=network                             - use regtest or testnet
+  -n=network  --network=network                             - use regtest, devnet or testnet
               --dpns-tld-identity-private-key=private_key   - top level identity private key
               --dpns-tld-identity-id=identity_id            - top level identity id
               --dpns-contract-id=contract_id                - dpns contract id

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -12,7 +12,7 @@ Usage: test <seed> [options]
               --npm-install=pkg                             - install npm package before running the suite
   -s=a,b,c    --scope=a,b,c                                 - test scope to run
   -k=key      --faucet-key=key                              - faucet private key string
-  -n=network  --network=network                             - use regtest or testnet
+  -n=network  --network=network                             - use regtest, devnet or testnet
               --dpns-tld-identity-private-key=private_key   - top level identity private key
               --dpns-tld-identity-id=identity_id            - top level identity id
               --dpns-contract-id=contract_id                - dpns contract id


### PR DESCRIPTION
## Issue being fixed or feature implemented
Confusing docs led me to believe `regtest` and `testnet` were the only options for the `--network` argument.

## What was done?
Explicitly state that `devnet` is also an option.


## How Has This Been Tested?
Tested on Palinka.


## Breaking Changes
None


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [ ] I have assigned this pull request to a milestone
