### PR TITLE
fix: update tests to reflect lastest dapi changes

### DIFF
--- a/.github/workflows/.env
+++ b/.github/workflows/.env
@@ -1,4 +1,4 @@
 #DRIVE_BRANCH=fix-missing-proof-signature
-#DAPI_BRANCH=update-dpp
+DAPI_BRANCH=v0.21-dev
 DASHMATE_BRANCH=v0.21-dev
 #SDK_BRANCH=

--- a/test/functional/core/getBlock.spec.js
+++ b/test/functional/core/getBlock.spec.js
@@ -38,17 +38,10 @@ describe('Core', () => {
       expect(block).to.be.an.instanceOf(Block);
     });
 
-    it('should respond with an invalid argument error if the block by height was not found', async () => {
-      let broadcastError;
-      try {
-        await client.getDAPIClient().core.getBlockByHeight(1000000000);
-      } catch (e) {
-        broadcastError = e;
-      }
+    it('should respond with a null when the block by height was not found', async () => {
+      const block = await client.getDAPIClient().core.getBlockByHeight(1000000000);
 
-      expect(broadcastError).to.exist();
-      expect(broadcastError.message).to.equal('3 INVALID_ARGUMENT: Invalid block height');
-      expect(broadcastError.code).to.equal(3);
+      expect(block).to.be.null();
     });
 
     it('should respond with null if the block by hash was not found', async () => {

--- a/test/functional/platform/Document.spec.js
+++ b/test/functional/platform/Document.spec.js
@@ -249,8 +249,9 @@ describe('Platform', () => {
       expect(proof.rootTreeProof).to.be.an.instanceof(Uint8Array);
       expect(proof.rootTreeProof.length).to.be.greaterThan(0);
 
-      expect(proof.storeTreeProof).to.be.an.instanceof(Uint8Array);
-      expect(proof.storeTreeProof.length).to.be.greaterThan(0);
+      expect(proof.storeTreeProofs).to.exist();
+      expect(proof.storeTreeProofs.documentsProof).to.be.an.instanceof(Uint8Array);
+      expect(proof.storeTreeProofs.documentsProof.length).to.be.greaterThan(0);
 
       expect(proof.signatureLLMQHash).to.be.an.instanceof(Uint8Array);
       expect(proof.signatureLLMQHash.length).to.be.equal(32);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Tests not working for the most recent versions of dapi

## What was done?
<!--- Describe your changes in detail -->
- Rename the proof field in the document test from `proof` to `proofs`
- `getBlockByHeight` now returns null instead of error: https://github.com/dashevo/js-dapi-client/blob/v0.21-dev/lib/methods/core/getBlockByHeightFactory.js#L37

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
