### PR TITLE
fix: don't upgrade evidence maxBytes value

### DIFF
--- a/test/functional/platform/featureFlags.spec.js
+++ b/test/functional/platform/featureFlags.spec.js
@@ -47,6 +47,7 @@ describe('Platform', () => {
               seconds: Math.trunc(evidence.maxAgeDuration / 1000000000) + 1,
               nanos: (evidence.maxAgeDuration % 1000000000) + 1,
             },
+            // on schnaps, maxBytes default value is empty, and we can't revert it back
             // maxBytes: +evidence.maxBytes + 1,
           },
         };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
evidence maxBytes contains empty value on schnaps. So we can't revert it back during the testing process.

## What was done?
<!--- Describe your changes in detail -->
Don't upgrade evidence maxBytes value

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
